### PR TITLE
Union Type List Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,25 +153,6 @@ class GetUserByType extends \Filecage\GraphQL\Factory\Queries\Query {
 }
 ```
 
-#### Using Union Return Types
-GraphQL and PHP both support union types. However, GraphQL requires them to be [named and unique](https://graphql.org/learn/schema/#union-types)
-throughout a schema. This is why all union types need to be named using the `TypeAlias` attribute annotation:
-
-```php
-class MyModel {
-    #[\Filecage\GraphQL\Annotations\Attributes\TypeAlias('FooBarUnion')]
-    public readonly Foo|Bar $baz;
-}
-```
-
-The `TypeAlias` attribute accepts enums and will use the enum's name or, if it's string backed, its value. 
-
-If this annotation is missing, the library will throw an `InvalidTypeException` with the message
-> Missing union type `TypeAlias` attribute declaration
-upon creating the type.
-
-The library will also ensure that return signatures match when using identical union type names.
-
 ### Resolving with dependencies
 It is most likely that when resolving a query, you would want to use a dependency like a database connection or an API client or whatever.
 To do so, a `Query` may return a `callable` instead of an object or `null`. This callable will then be passed to the previously defined
@@ -225,6 +206,39 @@ class Person {
     function isCelebrity() {} // This will be part of the schema because it has the `Promote` attribute
 }
 ```
+
+#### Resolving Union Types
+GraphQL and PHP both support union types. However, GraphQL requires them to be [named and unique](https://graphql.org/learn/schema/#union-types)
+throughout a schema. This is why all union types need to be named using the `TypeAlias` attribute annotation:
+
+Additionally, only object types are allowed as union types in GraphQL.
+
+#### Single Attribute Union Type
+```php
+class MyModel {
+    #[\Filecage\GraphQL\Annotations\Attributes\TypeAlias('FooBarUnion')]
+    public readonly Foo|Bar $baz;
+}
+```
+
+#### List Attribute Union Type
+```php
+class MyModel {
+    #[\Filecage\GraphQL\Annotations\Attributes\Contains(Foo::class)];
+    #[\Filecage\GraphQL\Annotations\Attributes\Contains(Bar::class)];
+    #[\Filecage\GraphQL\Annotations\Attributes\TypeAlias('FooBarUnion')]
+    public readonly array $baz;
+}
+```
+
+#### Managing Union Type Names Throughout The Schema
+The `TypeAlias` attribute accepts enums and will use the enum's name or, if it's string backed, its value.
+
+If this annotation is missing, the library will throw an `InvalidTypeException` with the message
+> Missing union type `TypeAlias` attribute declaration
+upon creating the type.
+
+The library will also ensure that return signatures match when using identical union type names.
 
 ### Resolving Internal Types
 Some internal types will be mapped, so they won't break your existing interface. A good example is `DateTimeInterface`, that

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=8.2",
         "webonyx/graphql-php": "^15.5",
-        "filecage/graphql-annotations": "dev-main#87f7dd5"
+        "filecage/graphql-annotations": "dev-main#06e62f1"
     },
     "license": "MIT",
     "autoload": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" cacheDirectory=".phpunit.cache">
+<phpunit
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+        cacheDirectory=".phpunit.cache"
+        displayDetailsOnTestsThatTriggerWarnings="true"
+>
   <coverage/>
   <testsuites>
     <testsuite name="all tests">

--- a/src/Factories/Cache.php
+++ b/src/Factories/Cache.php
@@ -39,7 +39,7 @@ final class Cache {
         return array_key_exists($key, $this->unions);
     }
 
-    function getUnionType (string $key) : ?Type {
+    function getUnionType (string $key) : ?UnionType {
         return $this->unions[$key]['type'] ?? null;
     }
 
@@ -47,7 +47,7 @@ final class Cache {
         return $this->unions[$key]['signature'] ?? null;
     }
 
-    function setUnion (string $key, Type $type, string $signature) : void {
+    function setUnion (string $key, UnionType $type, string $signature) : void {
         $this->unions[$key] = [
             'signature' => $signature,
             'type' => $type,

--- a/src/Factories/IterableObjectTypeFactory.php
+++ b/src/Factories/IterableObjectTypeFactory.php
@@ -20,16 +20,15 @@ final class IterableObjectTypeFactory extends ObjectTypeFactory {
         parent::__construct($factory, $cache, $this->reflectionClass);
     }
 
+    /**
+     * @throws InvalidTypeException
+     */
     function create (): Type {
         $contains = $this->reflectionClass->getAttributes(Contains::class);
         if (empty($contains)) {
             return parent::create();
         }
 
-        if (count($contains) > 1) {
-            throw new InvalidTypeException("Type clarification is too ambiguous (expected none or exactly 1 `Contains` attribute) for iterator `{{$this->reflectionClass->getName()}}`");
-        }
-
-        return $this->mapTypeForContains($contains[0]->newInstance());
+        return $this->mapTypeForContains($this->reflectionClass, ...array_map(fn(\ReflectionAttribute $contains) => $contains->newInstance(), $contains));
     }
 }

--- a/tests/Fixtures/Containers/PersonOrPetContainer.php
+++ b/tests/Fixtures/Containers/PersonOrPetContainer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Filecage\GraphQL\FactoryTests\Fixtures\Containers;
+
+use Filecage\GraphQL\Annotations\Attributes\Contains;
+use Filecage\GraphQL\Annotations\Attributes\TypeAlias;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Person;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Pet;
+
+#[Contains(Pet::class)]
+#[Contains(Person::class)]
+#[TypeAlias('PersonOrPetContainerUnion')]
+class PersonOrPetContainer extends \ArrayIterator {
+
+    function __construct(Pet|Person ...$peopleOrPets) {
+        parent::__construct($peopleOrPets);
+    }
+
+}

--- a/tests/Fixtures/Containers/PetsContainer.php
+++ b/tests/Fixtures/Containers/PetsContainer.php
@@ -8,8 +8,8 @@ use Filecage\GraphQL\FactoryTests\Fixtures\Types\Pet;
 #[Contains(Pet::class)]
 class PetsContainer extends \ArrayIterator {
 
-    function __construct(Pet ...$pets) {
-        parent::__construct($pets);
+    function __construct(Pet ...$peopleOrPets) {
+        parent::__construct($peopleOrPets);
     }
 
 }

--- a/tests/Fixtures/Queries/GetPersonOrPetContainer.php
+++ b/tests/Fixtures/Queries/GetPersonOrPetContainer.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Filecage\GraphQL\FactoryTests\Fixtures\Queries;
+
+use Filecage\GraphQL\Factory\Queries\Query;
+use Filecage\GraphQL\FactoryTests\Fixtures\Containers\PersonOrPetContainer;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Person;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Pet;
+
+class GetPersonOrPetContainer extends Query {
+
+    function __construct() {
+        parent::__construct(
+            description: 'Generates a list of mixed outputs to test union sub-types containers',
+            returnTypeClassName: PersonOrPetContainer::class,
+        );
+    }
+
+    function resolve (mixed $rootValue = null, array $arguments = []): PersonOrPetContainer {
+        return new PersonOrPetContainer(
+            new Person('David'),
+            new Pet('Nox'),
+        );
+    }
+}

--- a/tests/Fixtures/Types/UnionTypes/ListUnionType.php
+++ b/tests/Fixtures/Types/UnionTypes/ListUnionType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes;
+
+use Filecage\GraphQL\Annotations\Attributes\Contains;
+use Filecage\GraphQL\Annotations\Attributes\TypeAlias;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Person;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Pet;
+
+final class ListUnionType {
+
+    #[Contains(Person::class)]
+    #[Contains(Pet::class)]
+    #[TypeAlias('PersonOrPetListUnion')]
+    public readonly array $personOrPet;
+
+}

--- a/tests/Fixtures/Types/UnionTypes/ListUnionTypeContainerWithMissingContains.php
+++ b/tests/Fixtures/Types/UnionTypes/ListUnionTypeContainerWithMissingContains.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes;
+
+
+use Filecage\GraphQL\Annotations\Attributes\Contains;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Person;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Pet;
+
+#[Contains(Person::class)]
+#[Contains(Pet::class)]
+final class ListUnionTypeContainerWithMissingContains implements \Iterator {
+
+    public function current (): mixed {
+        // TODO: Implement current() method.
+    }
+
+    public function next (): void {
+        // TODO: Implement next() method.
+    }
+
+    public function key (): mixed {
+        // TODO: Implement key() method.
+    }
+
+    public function valid (): bool {
+        // TODO: Implement valid() method.
+    }
+
+    public function rewind (): void {
+        // TODO: Implement rewind() method.
+    }
+}

--- a/tests/Fixtures/Types/UnionTypes/ListUnionTypePropertyWithMissingContains.php
+++ b/tests/Fixtures/Types/UnionTypes/ListUnionTypePropertyWithMissingContains.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes;
+
+
+use Filecage\GraphQL\Annotations\Attributes\Contains;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Person;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Pet;
+
+final class ListUnionTypePropertyWithMissingContains {
+    #[Contains(Person::class)]
+    #[Contains(Pet::class)]
+    readonly array $personOrPet;
+}

--- a/tests/Fixtures/Types/UnionTypes/ListUnionTypeReturnWithMissingContains.php
+++ b/tests/Fixtures/Types/UnionTypes/ListUnionTypeReturnWithMissingContains.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes;
+
+
+use Filecage\GraphQL\Annotations\Attributes\Contains;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Person;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\Pet;
+
+final class ListUnionTypeReturnWithMissingContains {
+    #[Contains(Person::class)]
+    #[Contains(Pet::class)]
+    function getPersonOrPet() : array {
+        return [];
+    }
+}

--- a/tests/UnionTypeTest.php
+++ b/tests/UnionTypeTest.php
@@ -3,9 +3,13 @@
 namespace Filecage\GraphQL\FactoryTests;
 
 use Filecage\GraphQL\Factory\Exceptions\InvalidTypeException;
-use Filecage\GraphQL\Factory\Factory;
 use Filecage\GraphQL\FactoryTests\Fixtures\Queries\GetFamilyMembers;
 use Filecage\GraphQL\FactoryTests\Fixtures\Queries\GetPersonOrPet;
+use Filecage\GraphQL\FactoryTests\Fixtures\Queries\GetPersonOrPetContainer;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\ListUnionType;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\ListUnionTypeContainerWithMissingContains;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\ListUnionTypePropertyWithMissingContains;
+use Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\ListUnionTypeReturnWithMissingContains;
 use Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\UnionTypeWithMissingTypeAlias;
 use Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\UnionTypeWithMultipleTypeAliasAndDifferentSignature;
 use Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\UnionTypeWithSameSignatureButNullableAndNonNullable;
@@ -28,6 +32,14 @@ class UnionTypeTest extends TestCase {
         $this->assertMatchesSnapshot($result, new JsonDriver());
     }
 
+    function testExpectsUnionSubtypeFromContainerToBeResolved () {
+        $schema = new Schema(['query' => $this->provideFactory()->forQuery(GetPersonOrPetContainer::class)]);
+        $result = GraphQL::executeQuery($schema, '{ GetPersonOrPetContainer { __typename ... on Person { name } ... on Pet { name } } }');
+
+        $this->assertMatchesGraphQLSchemaSnapshot($schema);
+        $this->assertMatchesSnapshot($result, new JsonDriver());
+    }
+
     function testExpectsSimilarUnionSubtypesToBeResolved () {
         $schema = new Schema(['query' => $this->provideFactory()->forQuery(GetPersonOrPet::class, GetFamilyMembers::class)]);
         $result = GraphQL::executeQuery($schema, '{GetPersonOrPet { personOrPet { __typename ... on Person { name } ... on Pet { name } } } GetFamilyMembers  { personOrPet { __typename ... on Person { name } ... on Pet { name } } } }');
@@ -36,12 +48,37 @@ class UnionTypeTest extends TestCase {
         $this->assertMatchesSnapshot($result, new JsonDriver());
     }
 
+    function testExpectsUnionSubtypeFromListToBeCreated () {
+        $this->assertMatchesTypeSnapshot($this->provideFactory()->forType(ListUnionType::class));
+    }
+
     function testExpectsTypeWithSameAliasButOneNullableAndOneNonNullable () {
         $this->assertMatchesTypeSnapshot($this->provideFactory()->forType(UnionTypeWithSameSignatureButNullableAndNonNullable::class));
     }
 
     function testExpectsTypeWithStringBackedEnum () {
         $this->assertMatchesTypeSnapshot($this->provideFactory()->forType(UnionTypeWithStringBackedEnumTypeAlias::class));
+    }
+
+    function testExpectsExceptionForListUnionPropertyIfContainsIsMissing () {
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Missing union type `TypeAlias` attribute declaration for property `Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\ListUnionTypePropertyWithMissingContains::$personOrPet`');
+
+        $this->provideFactory()->forType(ListUnionTypePropertyWithMissingContains::class);
+    }
+
+    function testExpectsExceptionForListUnionReturnIfContainsIsMissing () {
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Missing union type `TypeAlias` attribute declaration for return type of `Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\ListUnionTypeReturnWithMissingContains::getPersonOrPet()`');
+
+        $this->provideFactory()->forType(ListUnionTypeReturnWithMissingContains::class);
+    }
+
+    function testExpectsExceptionForListUnionContainerIfContainsIsMissing () {
+        $this->expectException(InvalidTypeException::class);
+        $this->expectExceptionMessage('Missing union type `TypeAlias` attribute declaration for class `Filecage\GraphQL\FactoryTests\Fixtures\Types\UnionTypes\ListUnionTypeContainerWithMissingContains`');
+
+        $this->provideFactory()->forType(ListUnionTypeContainerWithMissingContains::class);
     }
 
     function testExpectsExceptionIfTypeAliasIsMissing () {

--- a/tests/__snapshots__/UnionTypeTest__testExpectsUnionSubtypeFromContainerToBeResolved__1.gql
+++ b/tests/__snapshots__/UnionTypeTest__testExpectsUnionSubtypeFromContainerToBeResolved__1.gql
@@ -1,0 +1,19 @@
+type Query {
+  "Generates a list of mixed outputs to test union sub-types containers"
+  GetPersonOrPetContainer: [PersonOrPetContainerUnion!]
+}
+
+union PersonOrPetContainerUnion = Pet | Person
+
+type Pet {
+  name: String!
+}
+
+type Person {
+  name: String!
+
+  "SHA256 hash of the Persons's name"
+  nameHashed: String!
+
+  isCelebrity: Boolean!
+}

--- a/tests/__snapshots__/UnionTypeTest__testExpectsUnionSubtypeFromContainerToBeResolved__2.json
+++ b/tests/__snapshots__/UnionTypeTest__testExpectsUnionSubtypeFromContainerToBeResolved__2.json
@@ -1,0 +1,14 @@
+{
+    "data": {
+        "GetPersonOrPetContainer": [
+            {
+                "__typename": "Person",
+                "name": "David"
+            },
+            {
+                "__typename": "Pet",
+                "name": "Nox"
+            }
+        ]
+    }
+}

--- a/tests/__snapshots__/UnionTypeTest__testExpectsUnionSubtypeFromListToBeCreated__1.gql
+++ b/tests/__snapshots__/UnionTypeTest__testExpectsUnionSubtypeFromListToBeCreated__1.gql
@@ -1,0 +1,3 @@
+type ListUnionType {
+  personOrPet: [PersonOrPetListUnion!]!
+}


### PR DESCRIPTION
Adds support for union types in lists:
```php
#[Contains(Foo::class)];
#[Contains(Bar::class)];
#[TypeAlias('FooBarUnion')];
public readonly array $fooOrBar;
```